### PR TITLE
Update consumer-rules.pro to fix release builds

### DIFF
--- a/platforms/android/library/consumer-rules.pro
+++ b/platforms/android/library/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Moshi adds this file, which won't be present in release builds and can break the build
+-dontwarn com.google.devtools.ksp.processing.SymbolProcessorProvider


### PR DESCRIPTION
I tried this locally and it seems to fix the build issues we had with our release versions.