### PR TITLE
Don't include tests in build output

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 build
 .eslintignore
 babel.config.js
+jest.config.ts

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -outDir build src/*.ts",
     "start": "ts-node ./src/build.ts",
     "prepare": "yarn build && yarn start",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build"
   ],
   "scripts": {
-    "build": "tsc -outDir build src/*.ts",
+    "build": "tsc --project tsconfig.build.json",
     "start": "ts-node ./src/build.ts",
     "prepare": "yarn build && yarn start",
     "lint": "eslint .",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+ "extends": "./tsconfig.json",
+ "exclude": ["./test/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "declarationMap": true,
     "outDir": "build"
   },
-  "include": ["./src/**/*.ts"]
+  "include": ["./src/**/*.ts", "./test/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "build"
-  }
+  },
+  "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
After recently adding tests, they were included in the build output with a different folder structure.

This mean that the ["main" within package.json](https://github.com/matrix-org/emojibase-bindings/blob/main/package.json#L5) was incorrect.( as the structire was now `/build/src/emoji.ts` vs `/build/emoji.ts`).

I don't think we need to include tests in build output so removing, which will fix this reference.