### PR TITLE
Remove un-necessary async declaration for load function

### DIFF
--- a/platforms/ios/Emojibase/EmojibaseDatasource.swift
+++ b/platforms/ios/Emojibase/EmojibaseDatasource.swift
@@ -22,7 +22,7 @@ public struct EmojibaseDatasource {
     
     public init() {}
     
-    public func load() async throws -> EmojibaseStore {
+    public func load() throws -> EmojibaseStore {
         guard let jsonDataURL = Self.jsonFile else {
             throw DatasourceError.fileNotFound
         }

--- a/platforms/ios/EmojibaseTests/EmojibaseTests.swift
+++ b/platforms/ios/EmojibaseTests/EmojibaseTests.swift
@@ -20,8 +20,8 @@ final class EmojibaseTests: XCTestCase {
     
     var store: EmojibaseStore?
     
-    override func setUp() async throws {
-        self.store = try? await EmojibaseDatasource().load()
+    override func setUp() throws {
+        self.store = try? EmojibaseDatasource().load()
     }
     
     func testSpecificEmoji() async throws {


### PR DESCRIPTION
`EmojibaseDatasource.load() `only uses synchronous APIs, so it doesn’t need to be async. This change removes the async requirement, making it clear that the method can be called directly without await.