### PR TITLE
Android: improve performance and ensure immutability of data

### DIFF
--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0'
+    implementation 'dev.zacsweers.moshix:moshi-immutable-adapters:0.31.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/platforms/android/library/src/main/java/io/element/android/emojibasebindings/EmojibaseDatasource.kt
+++ b/platforms/android/library/src/main/java/io/element/android/emojibasebindings/EmojibaseDatasource.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
+import dev.zacsweers.moshix.adapters.immutable.ImmutableCollectionsJsonAdapterFactory
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
 import java.io.IOException
 import java.io.InputStream
 
@@ -11,18 +14,19 @@ class EmojibaseDatasource {
 
     @Throws(IOException::class)
     fun load(context: Context): EmojibaseStore {
-        val inputStream: InputStream = context.assets.open("emojibase.json");
+        val inputStream: InputStream = context.assets.open("emojibase.json")
         val json = inputStream.bufferedReader().use { it.readText() }
-        val moshi = Moshi.Builder().build()
+        val moshi = Moshi.Builder().add(ImmutableCollectionsJsonAdapterFactory()).build()
         val type = Types.newParameterizedType(
-            Map::class.java,
+            ImmutableMap::class.java,
             EmojibaseCategory::class.java,
             Types.newParameterizedType(
-                List::class.java,
+                ImmutableList::class.java,
                 Emoji::class.java
             )
         )
-        val adapter = moshi.adapter<Map<EmojibaseCategory, List<Emoji>>>(type)
-        return adapter.fromJson(json)?.let { EmojibaseStore(categories = it) } ?: throw JsonDataException("Failed to parse emojibase.json")
+        val adapter = moshi.adapter<ImmutableMap<EmojibaseCategory, ImmutableList<Emoji>>>(type)
+        return adapter.fromJson(json)?.let { EmojibaseStore(categories = it) }
+            ?: throw JsonDataException("Failed to parse emojibase.json")
     }
 }

--- a/platforms/android/library/src/main/java/io/element/android/emojibasebindings/EmojibaseDatasource.kt
+++ b/platforms/android/library/src/main/java/io/element/android/emojibasebindings/EmojibaseDatasource.kt
@@ -7,15 +7,16 @@ import com.squareup.moshi.Types
 import dev.zacsweers.moshix.adapters.immutable.ImmutableCollectionsJsonAdapterFactory
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
+import okio.buffer
+import okio.source
 import java.io.IOException
-import java.io.InputStream
 
 class EmojibaseDatasource {
 
     @Throws(IOException::class)
     fun load(context: Context): EmojibaseStore {
-        val inputStream: InputStream = context.assets.open("emojibase.json")
-        val json = inputStream.bufferedReader().use { it.readText() }
+        val inputStream = context.assets.open("emojibase.json")
+        val jsonBuffer = inputStream.source().buffer()
         val moshi = Moshi.Builder().add(ImmutableCollectionsJsonAdapterFactory()).build()
         val type = Types.newParameterizedType(
             ImmutableMap::class.java,
@@ -26,7 +27,7 @@ class EmojibaseDatasource {
             )
         )
         val adapter = moshi.adapter<ImmutableMap<EmojibaseCategory, ImmutableList<Emoji>>>(type)
-        return adapter.fromJson(json)?.let { EmojibaseStore(categories = it) }
+        return adapter.fromJson(jsonBuffer)?.let { EmojibaseStore(categories = it) }
             ?: throw JsonDataException("Failed to parse emojibase.json")
     }
 }

--- a/platforms/android/library/src/main/java/io/element/android/emojibasebindings/Models.kt
+++ b/platforms/android/library/src/main/java/io/element/android/emojibasebindings/Models.kt
@@ -2,27 +2,30 @@ package io.element.android.emojibasebindings
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableList
 
 data class EmojibaseStore(
-    var categories: Map<EmojibaseCategory, List<Emoji>>
-)
-
-fun EmojibaseStore.emojisFor(category: EmojibaseCategory): List<Emoji>? {
-    return categories[category]
+    val categories: ImmutableMap<EmojibaseCategory, ImmutableList<Emoji>>
+) {
+    val allEmojis: ImmutableList<Emoji> by lazy {
+        categories.values.flatten().toImmutableList()
+    }
 }
 
-val EmojibaseStore.allEmojis: List<Emoji> get() {
-    return categories.values.flatten()
+fun EmojibaseStore.emojisFor(category: EmojibaseCategory): ImmutableList<Emoji>? {
+    return categories[category]
 }
 
 @JsonClass(generateAdapter = true)
 data class Emoji(
     val hexcode: String,
     val label: String,
-    val tags: List<String>?,
-    val shortcodes: List<String>,
+    val tags: ImmutableList<String>?,
+    val shortcodes: ImmutableList<String>,
     val unicode: String,
-    val skins: List<EmojiSkin>?
+    val skins: ImmutableList<EmojiSkin>?
 )
 
 @JsonClass(generateAdapter = true)


### PR DESCRIPTION
## Changes:
- Make `allEmojis` lazy so it's computed only once.
- Change `categories` to a `val` and all list and maps `immutable` to ensure compatibility with Jetpack Compose. This needed adding some special adapters.
- Have Moshi also handle the data reading through okio instead of doing it ourselves.