### PR TITLE
Android: fix publishing after plugin upgrade.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           build-root-directory: platforms/android
-          arguments: closeAndReleaseRepository
+          arguments: publishAndReleaseToMavenCentral
 
       - name: 🚀 Publish to npm
         id: npm-publish


### PR DESCRIPTION
We upgraded Vanniktech's Maven Publishing plugin and that changed the command use to publish an release a library.